### PR TITLE
fix README dependency install description

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add Markdown Provider as a dependency in your `Package.swift` file:
 ```swift
     dependencies: [
         ...,
-        .Package(url: "https://github.com/vapor-community/markdown-provider", majorVersion: 0)
+        .Package(url: "https://github.com/vapor-community/markdown-provider.git", majorVersion: 1)
     ]
 ```
 


### PR DESCRIPTION
There is now a v1.0.0 tag, update readme to use it. Install failed for me without it. 